### PR TITLE
SSM Parametersで管理可能な情報のうち、String型(暗号化不要)が正常に登録できない問題に対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ dist: build-docker ## create .tar.gz linux & darwin to /bin
 	cd bin && tar zcvf $(linux_name).tar.gz $(linux_name) && rm -f $(linux_name)
 	cd bin && tar zcvf $(darwin_name).tar.gz $(darwin_name) && rm -f $(darwin_name)
 
-build-cross: ## create to build for linux & darwin to bin/
+build-cross: clean ## create to build for linux & darwin to bin/
 	GOOS=linux GOARCH=amd64 go build -o bin/$(linux_name) $(LDFLAGS) *.go
 	GOOS=darwin GOARCH=amd64 go build -o bin/$(darwin_name) $(LDFLAGS) *.go
 

--- a/aws_ssm.go
+++ b/aws_ssm.go
@@ -51,10 +51,14 @@ func (s *SsmClient) PutParameter(name, value, ssmtype, kmsAlias, description str
 		Name:        aws.String(name),
 		Value:       aws.String(value),
 		Type:        aws.String(ssmtype),
-		KeyId:       aws.String(kmsAlias),
 		Description: aws.String(description),
 		Overwrite:   aws.Bool(true),
 	}
+
+	if ssmtype == "SecureString" {
+		param.KeyId = aws.String(kmsAlias)
+	}
+
 	result, err := s.Session.PutParameter(param)
 	if err != nil {
 		return nil, fmt.Errorf("failed ssm put param: %+v", err)


### PR DESCRIPTION
## 概要

SSM Parametersで管理可能な情報のうち、String型(暗号化不要)が正常に登録できない問題に対応しました。

## 詳細

`SecurityString`型(暗号化) のパラメータは正常に登録が可能だが、
`String`型(暗号化不要) のパラメータは **"KeyIdが不要"** というエラーが AWS より返却され正常に登録できなかった。

かんたんな分岐を追加し、 `String`型の場合に **KeyId** が送信されないようにしました。

## 動作確認

こちらを利用して SSM Parameters に `String` 型パラメータが追加できるようになることを確認しました。